### PR TITLE
Added shebang to job.sbatch

### DIFF
--- a/04-job-launchers/job.sbatch
+++ b/04-job-launchers/job.sbatch
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # SBATCH --ntasks-per-node=1
 
 source $(pwd)/../venv/bin/activate


### PR DESCRIPTION
User at Amazon believes this is required in order for Slurm to work properly.